### PR TITLE
Correct missing letter in a word

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,7 +54,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
       <p>
         We want to emphasize that we are not at odds with the project working on
         the original language. We appreciate everything they do to make the
-        language better, and our fork's main brach will continue to stay up to
+        language better, and our fork's main branch will continue to stay up to
         date with the upstream codebase. Our main goal is to ensure that the
         community has an alternative that aligns with their values and desire
         for unrestricted use.


### PR DESCRIPTION
In paragraph 4, "brach" changed to "branch".
